### PR TITLE
[LATAM] Fix typo in achievement description for triple agent

### DIFF
--- a/tf2c_steamachievements/3545060_loc_latam.vdf
+++ b/tf2c_steamachievements/3545060_loc_latam.vdf
@@ -56,7 +56,7 @@
 		"NEW_ACHIEVEMENT_226_26_NAME"	"Jugada gallina"
 		"NEW_ACHIEVEMENT_226_26_DESC"	"Persigue a una gallina hacia una muerte ambiental."
 		"NEW_ACHIEVEMENT_226_27_NAME"	"Agente triple"
-		"NEW_ACHIEVEMENT_226_27_DESC"	"Apuñala a jugadores de los tres equipos enemigos en una sola ronda de Cuatro jugadores."
+		"NEW_ACHIEVEMENT_226_27_DESC"	"Apuñala a jugadores de los tres equipos enemigos en una sola ronda de Cuatro Equipos."
 		"NEW_ACHIEVEMENT_226_28_NAME"	"Dominación total"
 		"NEW_ACHIEVEMENT_226_28_DESC"	"Consigue que tu equipo posea cada Punto de Control durante una ronda de Dominación."
 		"NEW_ACHIEVEMENT_226_29_NAME"	"Medalla de la vergüenza"


### PR DESCRIPTION
The current translation says to earn the achievement on a "four-player" match instead of a "four-team" match.
My PR corrects that.