### PR TITLE
Adapt Brazilian Portuguese localization to new content added by VermilionCosmos

### DIFF
--- a/tf2c_strings/tf2classified_brazilian.txt
+++ b/tf2c_strings/tf2classified_brazilian.txt
@@ -381,7 +381,7 @@
 // Generic
 "Tip_10_1"		"Como um Civilian, você é um pouco lento. Tente ao máximo acompanhar seus companheiros de equipe para ter uma chance melhor de sobrevivência."
 "Tip_10_2"		"Como um Civilian, você é o mais baixo de toda a sua equipe. Isso pode ser útil para se esconder atrás dos seus companheiros."
-"Tip_10_3"		"Como um Civilian, você é o único capaz de capturar Pontos de Controle nos modos de jogo VIP e Corrida VIP."
+"Tip_10_3"		"Como um Civilian, você é o único capaz de capturar Pontos de Controle nos modos de jogo VIP e Corrida de VIPs."
 "Tip_10_4"		"Como um Civilian, fique atento aos Snipers e Spies inimigos, pois eles são capazes de eliminá-lo instantaneamente."
 "Tip_10_5"		"Como um Civilian, aliados próximos ganham bônus de moral, recebendo assim um pequeno aumento de defesa e cura. Fique fora da visão inimiga e próximo da sua equipe."
 "Tip_10_6"		"Como um Civilian, pressione %attack2% enquanto estiver olhando para um companheiro de equipe para bancá-lo, dando-lhe uma grande vantagem na batalha."
@@ -1043,7 +1043,7 @@ A posse dos Pontos de Controle por cada equipe é aleatorizada no início de cad
 "TF_IM_Steel_Pit"	"Cuidado com o buraco!"
 
 // VIP Race
-"TF_IM_VIPR_Intro"	"Bem-vindo ao modo de jogo Corrida VIP"
+"TF_IM_VIPR_Intro"	"Bem-vindo ao modo de jogo Corrida de VIPs"
 "TF_IM_VIPR_ToWin"	"Para vencer, você deve ajudar seu VIP a capturar o Ponto de Controle inimigo..."
 "TF_IM_VIPR_Escape"	"...e então escoltá-lo até a Zona de Fuga antes que a equipe inimiga possa fazer o mesmo!"
 "TF_IM_VIPR_Death"	"Se um VIP morrer, todos os pontos que ele tiver conquistado serão zerados."

--- a/tf2c_strings/tf2classified_brazilian.txt
+++ b/tf2c_strings/tf2classified_brazilian.txt
@@ -51,23 +51,31 @@
 // Teams
 // ----------------------------------------------------------------
 
-"TF_GreenTeam" 					"&5 GRN"
-"TF_YellowTeam" 				"&6 YLW"
+"TF_GreenTeam" 						"&5 GRN"
+"TF_YellowTeam" 					"&6 YLW"
 
-"TF_GreenTeam_Name"				"GRN"
-"TF_YellowTeam_Name"			"YLW"
+"TF_GreenTeam_Name"					"GRN"
+"TF_YellowTeam_Name"				"YLW"
 
-"TF_Other_Name"					"INIMIGOS"
+"TF_Other_Name"						"INIMIGOS"
 
 // Disguise Kit global disguise
-"Hud_Menu_Disguise_GlobalTeam"	"Disfarce Global: Todos os inimigos irão te ver como parte da sua própria equipe."
+"Hud_Menu_Disguise_GlobalTeam"		"Disfarce Global: Todos os inimigos irão te ver como parte da sua própria equipe."
 
 // Autobalance
-"TF_teamswitch_green"			"Você agora está na equipe GRN!"
-"TF_teamswitch_yellow"			"Você agora está na equipe YLW!"
+"TF_teamswitch_green"				"Você agora está na equipe GRN!"
+"TF_teamswitch_yellow"				"Você agora está na equipe YLW!"
 
-"TF_Team_Balanced"				"%s1 foi movido para a equipe %s2"
-"TF_Autobalance_TeamChangeDone"	"Você foi movido para a equipe %s1"
+// Chat Printouts
+"TF_Team_Balanced"					"%s1 foi movido para a equipe %s2"
+"TF_Autobalance_TeamChangeDone"		"Você foi movido para a equipe %s1"
+"TF_Name_Change"					"* %s1 mudou o nome para %s2"
+"TF_Joined_Game"					"%s1 entrou na partida"
+"TF_Left_Game"						"%s1 saiu da partida (%s2)"
+"TF_Joined_Team"					"%s1 entrou para a equipe %s2"
+"TF_Joined_AutoTeam" 				"%s1 foi automaticamente designado para a equipe %s2"
+"TF_AutoBalanced"					"%s1 foi movido para a equipe %s2 para balancear a partida"
+"TF_AutoBalance_Warning"			"Desequilíbrio de equipes detectado"
 
 // ----------------------------------------------------------------
 // Classes
@@ -344,7 +352,7 @@
 // Engineer
 "Tip_9_Count"	"20"
 // Generic
-"Tip_9_1"		"Como um Engineer, você precisa de metal para construir, reparar e melhorar seus edifícios. Colete pacotes de munição e armas caídas para obter mais metal."
+"Tip_9_1"		"Como um Engineer, você precisa de metal para construir, reparar e melhorar suas construções. Recolha armas de jogadores mortos como uma forma adicional de obter mais metal."
 "Tip_9_2"		"Como um Engineer, você pode fazer mais do que apenas manter suas contruções. Use sua Escopeta e sua Pistola para auxiliar em combates e defender suas construções."
 "Tip_9_3"		"Como um Engineer, fique de olho nos Spies inimigos que estão instalando Sabotadores em suas construções. Use sua Chave Inglesa para remover os Sabotadores."
 "Tip_9_4"		"Como um Engineer, lembre-se de aprimorar suas construções. Construções aprimoradas podem trazer grandes benefícios para você e sua equipe!"
@@ -866,6 +874,9 @@ Apenas combate honrado, espada contra espada!"
 // vipr_chopper
 "Chopper_cap_A"				"o Radar RED"
 "Chopper_cap_B"				"o Radar BLU"
+
+// 4plr_sisyphus
+"Sisyphus_cap_peak"			"o Pico"
 
 // ----------------------------------------------------------------
 // Gamemodes
@@ -1416,12 +1427,19 @@ A posse dos Pontos de Controle por cada equipe é aleatorizada no início de cad
 "TF_ClassRecord_MostPadJumps"			"Máx. de saltos:"
 "TF_ClassRecord_Alt_MostPadJumps"		"salto(s)"
 
-"StatPanel_PadJumps_Best"				"Você usou mais saltadores nessa rodada do que em sua melhor marca anterior."
+"StatPanel_Ubercharges_Best"			"Você usou mais ÜberCargas nesta rodada do que no seu recorde anterior."
+"StatPanel_Ubercharges_Tie"				"Você igualou seu recorde de ÜberCargas nesta rodada."
+"StatPanel_Ubercharges_Close"			"Você chegou perto do seu recorde de ÜberCargas nesta rodada."
+"StatPanel_MVM_Ubercharges_Best"		"Você usou mais ÜberCargas nesta rodada de Mann vs. Machine do que no seu recorde anterior."
+"StatPanel_MVM_Ubercharges_Tie"			"Você igualou seu recorde de ÜberCargas nesta rodada de Mann vs. Machine."
+"StatPanel_MVM_Ubercharges_Close"		"Você chegou perto do seu recorde de ÜberCargas nesta rodada de Mann vs. Machine."
+
+"StatPanel_PadJumps_Best"				"Seus saltadores foram usados mais vezes nesta rodada do que no seu recorde anterior."
 "StatPanel_PadJumps_Tie"				"Você igualou seu recorde de saltos com saltadores nessa rodada."
-"StatPanel_PadJumps_Close"				"Você quase bateu seu recorde de saltos com saltadores."
-"StatPanel_MVM_PadJumps_Best"			"Nessa rodada do Mann vs. Machine, você usou mais saltadores do que em qualquer outra partida, mesmo tendo alcançado seu melhor desempenho anterior."
-"StatPanel_MVM_PadJumps_Tie"			"Você igualou seu recorde de saltos sobre saltadores naquela rodada do Mann vs. Machine."
-"StatPanel_MVM_PadJumps_Close"			"Você quase bateu seu recorde de saltos sobre saltadores naquela rodada do Mann vs. Machine."
+"StatPanel_PadJumps_Close"				"Você chegou perto do seu recorde de saltos nos saltadores nesta rodada."
+"StatPanel_MVM_PadJumps_Best"			"Seus saltadores foram usados mais vezes nesta rodada de Mann vs. Machine do que no seu recorde anterior."
+"StatPanel_MVM_PadJumps_Tie"			"Você igualou seu recorde de saltos nos saltadores nesta rodada de Mann vs. Machine."
+"StatPanel_MVM_PadJumps_Close"			"Você chegou perto do seu recorde de saltos nos saltadores nesta rodada de Mann vs. Machine."
 // ----------------------------------------------------------------
 // Achievements
 // ----------------------------------------------------------------


### PR DESCRIPTION
I adapted all updates made by VermilionCosmos to work with the Brazilian Portuguese localization.

This PR incorporates the following upstream commit from VermilionCosmos:
[New string for Sisyphus Peak, new strings for ubercharge statpanel (to replace ones that said 'invuln' still), minor tweak to engineer tip referencing dropped ammo, strings for autobalance, and strings for future chat changes (translations needed).](https://github.com/tf2classified/tf2classified-translations/pull/31)

I also fixed minor grammatical errors in `tf2classified_brazilian.txt`.